### PR TITLE
Fix conflicting ids of notebook and Rmd import modals, closes #17

### DIFF
--- a/inst/addin/addin_files/submit.js
+++ b/inst/addin/addin_files/submit.js
@@ -43,3 +43,12 @@ function post_to_url(path, params, method) {
     document.body.appendChild(form);
     form._submit_function_(); //Call the renamed function.
 }
+$(
+  function() {
+    $( "#newurl" ).keydown(function(event) {
+      if(event.which == 13) {
+        exportrmd();
+      }
+    })
+  }
+)

--- a/inst/javascript/rcloud.rmd.js
+++ b/inst/javascript/rcloud.rmd.js
@@ -27,32 +27,32 @@
                             var that = this;
 
                             function create_import_file_dialog() {
-                                var notebook_raw = null;
+                                var rmd_raw = null;
                                 var notebook = null;
-                                var notebook_status = null;
-                                var notebook_filename = null;
+                                var rmd_status = null;
+                                var rmd_filename = null;
                                 var import_button = null;
 
                                 function do_upload(file) {
-                                    notebook_status.hide();
+                                    rmd_status.hide();
                                     var fr = new FileReader();
                                     fr.onloadend = function(e) {
-                                        notebook_status.show();
-                                        notebook_status.html(
+                                        rmd_status.show();
+                                        rmd_status.html(
                                             '<pre>' + fr.result.split("\n")
                                                 .slice(0,15)
                                                 .join("\n") + '\n...\n</pre>'
                                         );
                                         ui_utils.enable_bs_button(import_button);
-                                        notebook_raw = fr.result;
-                                        notebook_filename = file.name;
+                                        rmd_raw = fr.result;
+                                        rmd_filename = file.name;
                                     };
                                     fr.readAsText(file);
                                 }
 
                                 function do_import() {
                                     // Need to call back to R to import the notebook
-                                    oc.importRmd(notebook_raw, notebook_filename).then(
+                                    oc.importRmd(rmd_raw, rmd_filename).then(
                                         function(notebook) {
                                             console.log(notebook);
                                             if (notebook) {
@@ -70,23 +70,23 @@
                                 }
 
                                 var body = $('<div class="container"/>');
-                                var file_select = $('<input type="file" id="notebook-file-upload" size="50"></input>');
+                                var file_select = $('<input type="file" id="rmarkdown-file-upload" size="50"></input>');
 
                                 file_select
                                     .click(function() {
                                         ui_utils.disable_bs_button(import_button);
-                                        notebook_status.hide();
+                                        rmd_status.hide();
                                         file_select.val(null);
                                     })
                                     .change(function() {
                                         do_upload(file_select[0].files[0]);
                                     });
 
-                                notebook_status = $('<div />');
-                                notebook_status.append(notebook_status);
+                                rmd_status = $('<div />');
+                                rmd_status.append(rmd_status);
 
                                 body.append($('<p/>').append(file_select))
-                                    .append($('<p/>').append(notebook_status.hide()));
+                                    .append($('<p/>').append(rmd_status.hide()));
                                 var cancel = $('<span class="btn btn-cancel">Cancel</span>')
                                     .on('click', function() { $(dialog).modal('hide'); });
                                 import_button = $('<span class="btn btn-primary">Import</span>')
@@ -98,18 +98,18 @@
                                     .append(cancel).append(import_button);
                                 var header = $(['<div class="modal-header">',
                                                 '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>',
-                                                '<h3>Import Notebook File</h3>',
+                                                '<h3>Import Rmarkdown File</h3>',
                                                 '</div>'].join(''));
-                                var dialog = $('<div id="import-notebook-file-dialog" class="modal fade"></div>')
+                                var dialog = $('<div id="import-rmarkdown-file-dialog" class="modal fade"></div>')
                                     .append($('<div class="modal-dialog"></div>')
                                             .append($('<div class="modal-content"></div>')
                                                     .append(header).append(body).append(footer)));
                                 $("body").append(dialog);
                                 dialog
                                     .on('show.bs.modal', function() {
-                                        $("#notebook-file-upload")[0].value = null;
-                                        notebook_status.text('');
-                                        notebook_status.hide();
+                                        $("#rmarkdown-file-upload")[0].value = null;
+                                        rmd_status.text('');
+                                        rmd_status.hide();
                                     });
 
                                 // keep selected file, in case repeatedly importing is helpful
@@ -120,7 +120,7 @@
                                 });
                                 return dialog;
                             }
-                            var dialog = $("#import-notebook-file-dialog");
+                            var dialog = $("#import-rmarkdown-file-dialog");
                             if(!dialog.length)
                                 dialog = create_import_file_dialog();
                             else


### PR DESCRIPTION
There was a conflict of file import dialog ids which was causing notebook import dialog to appear instead of Rmarkdown file import dialog.


This pull request also includes the fix for #20 - now the Rmarkdown import form is also submitted when the  '<return>' key is pressed on the 'Alternative RCloud URL' text input. 